### PR TITLE
Fix changing country with different fields

### DIFF
--- a/Form/EventListener/AddressEmbeddableTypeSubscriber.php
+++ b/Form/EventListener/AddressEmbeddableTypeSubscriber.php
@@ -174,6 +174,17 @@ class AddressEmbeddableTypeSubscriber implements EventSubscriberInterface
         foreach ($unused_fields as $field) {
             $form->remove($field);
         }
+
+        if ($form->getData() !== $data) {
+            $addressEmbeddable = new AddressEmbeddable();
+            foreach ($data as $field => $value) {
+                $method = 'set'.ucfirst($field);
+                if (method_exists($addressEmbeddable, $method)) {
+                    $addressEmbeddable->{$method}($value);
+                }
+            }
+            $form->setData($addressEmbeddable);
+        }
     }
 
     private function getFieldOverrides(FormInterface $form)


### PR DESCRIPTION
Example: from a country with a postal code to a country without postal code it will trigger an error for the postal code field when you submit the form: "This value should be blank"

You can try with France (postal code is required) to Congo-Kinshasa (no postal code)