### PR TITLE
Keep compatibility with commerceguys/addressing v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.4 | ^8.0",
-        "commerceguys/addressing": "^2",
+        "commerceguys/addressing": "^1 | ^2",
         "doctrine/orm": "^2.6",
         "symfony/form": "^4.4 | ^5.3 | ^6.0",
         "symfony/framework-bundle": "^4.4 | ^5.3 | ^6.0"


### PR DESCRIPTION
https://github.com/daften/addressing-bundle/commit/74af9afe7376e6a2f8a1e566ae93985e20b18a25 changed compatibility for commerceguys/addressing, but i think than keeping compat with v1 should be done to have a smooth transitional time (the same way it is compatible with php 7 or 8)